### PR TITLE
HTTP-1 Fixed interceptor discarding parsed JSON

### DIFF
--- a/pkg/interceptors.go
+++ b/pkg/interceptors.go
@@ -9,7 +9,7 @@ import (
 
 type Format string
 
-const FORMAT = "Format"
+const FORMAT = "__FORMAT"
 
 const (
 	STRING Format = "String"
@@ -61,7 +61,7 @@ func extractResponseBody(response *http.Response) map[string]interface{} {
 	response.Body = io.NopCloser(&buf)
 	switch {
 	case jsonErr == nil:
-		responseBody = map[string]interface{}{FORMAT: JSON}
+		responseBody[FORMAT] = JSON
 	default:
 		responseBody = map[string]interface{}{FORMAT: STRING}
 	}

--- a/pkg/interceptors_test.go
+++ b/pkg/interceptors_test.go
@@ -67,3 +67,50 @@ func TestWithStatusCodeInterceptor(t *testing.T) {
 		}
 	})
 }
+
+func TestJsonFormatKeyAndParsedBody(t *testing.T) {
+	t.Run("validates JSON FORMAT key and parsed body", func(t *testing.T) {
+		expectedStatus := "ok"
+		var receivedBody map[string]interface{}
+
+		interceptor := func(body map[string]interface{}, response *http.Response) error {
+			receivedBody = body
+			return nil
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"status":"ok"}`))
+		}))
+		defer server.Close()
+
+		req := http_proxy.NewRequest("GET", server.URL)
+		req.WithGenericInterceptor(interceptor)
+		resp, err := req.Send()
+
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status code 200, got %d", resp.StatusCode)
+		}
+		if receivedBody == nil {
+			t.Errorf("expected body to be parsed, got nil")
+		} else {
+			format, formatExists := receivedBody[http_proxy.FORMAT]
+			if !formatExists {
+				t.Errorf("expected FORMAT key in parsed body")
+			}
+			if format != http_proxy.JSON {
+				t.Errorf("expected FORMAT to be 'JSON', got %v", format)
+			}
+			status, statusExists := receivedBody["status"]
+			if !statusExists {
+				t.Errorf("expected 'status' key in parsed body")
+			}
+			if status != expectedStatus {
+				t.Errorf("expected status to be '%s', got '%s'", expectedStatus, status)
+			}
+		}
+	})
+}


### PR DESCRIPTION
# Description

Fixed a bug that was causing the parsed body to be discarded when applying the format key in the interceptors

# Ticket

# Demo

Check review for explanation


