### PR TITLE
HTTP-2 Added function to simplify usage of JWT Authorization

### DIFF
--- a/pkg/headers.go
+++ b/pkg/headers.go
@@ -1,5 +1,7 @@
 package http_proxy
 
+import "fmt"
+
 func (requestIntent *ProxiedRequestImpl) AddHeader(key string, value string) ProxiedRequest {
 	requestIntent.verifyUnderlyingRequestNotGenerated()
 	if _, isFound := requestIntent.headers[key]; !isFound {
@@ -29,4 +31,8 @@ func (requestIntent *ProxiedRequestImpl) SetMultiValueHeaders(headers map[string
 		requestIntent.headers[key] = values
 	}
 	return requestIntent
+}
+
+func (requestIntent *ProxiedRequestImpl) SetJWTAuthToken(token string) ProxiedRequest {
+	return requestIntent.SetHeader("Authorization", fmt.Sprintf("Bearer %s", token))
 }

--- a/pkg/headers_test.go
+++ b/pkg/headers_test.go
@@ -134,3 +134,30 @@ func TestSetMultiValueHeaders(t *testing.T) {
 		}
 	})
 }
+
+func TestSetJWTAuthToken(t *testing.T) {
+	t.Run("SetJWTAuthToken sets the Authorization header", func(t *testing.T) {
+		expectedToken := "some-jwt-token"
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authHeader := r.Header.Get("Authorization")
+			expectedAuthHeader := "Bearer " + expectedToken
+			if authHeader != expectedAuthHeader {
+				t.Errorf("expected Authorization header to be '%s', got '%s'", expectedAuthHeader, authHeader)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		req := http_proxy.NewRequest("GET", server.URL)
+		req.SetJWTAuthToken(expectedToken)
+		resp, err := req.Send()
+
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status code 200, got %d", resp.StatusCode)
+		}
+	})
+}


### PR DESCRIPTION
# Description
Added function to simplify adding an "Authorization" header for JWT Authentication tokens.

# Ticket

# Demo
```golang
myToken := "some-jwt-token"

response, err := http_proxy.NewRequest(method, url).SetJWTAuthToken(myToken).Send()
```